### PR TITLE
chore(.github): add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"          
+    directory: "/"                    
+    schedule:
+      interval: "daily"               
+    open-pull-requests-limit: 5
+    rebase-strategy: "auto"
+    registries:
+      - github-private
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+registries:
+  github-private:
+    type: "npm-registry"
+    url: "https://npm.pkg.github.com"
+    # use the default DEPENDABOT_TOKEN, or create a PAT with read:packages
+    token: "${{ secrets.DEPENDABOT_TOKEN }}"


### PR DESCRIPTION
### Description

#### Overview
This PR adds dependabot for automatically open PRs with new packages, using also GH tokens `DEPENDABOT_TOKEN` as secret for Midnight private NPM packages.

#### Resolves
N/A

#### Key Changes
N/A

#### Testing
N/A

#### Notes
N/A
