### PR TITLE
fix(packages): compact compiler script

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,21 +39,26 @@ nvm use 22.14.0
 
 4. **Build Contracts Packages**:
    ```bash
-   pnpm build:contracts
+   # Navigate to each contract package and run build
+   cd contracts/access && pnpm build 
+   cd ../math && pnpm build
+   cd ../structs && pnpm build
    ```
-   - Runs `turbo run build`, which compiles `.compact` files (via `compact`) and builds all projects (e.g., TypeScript compilation, artifact copying).
-
+   - **Note**: Running `pnpm build:contracts`, `pnpm compact`, `pnpm compact:fast`, `pnpm compact:version`, or `pnpm compact:language-version` from the root may cause repetitive output due to Turbo's logging behavior. It's recommended to compile contracts individually from within each package directory.
+   - **Feature Request**: A logging output mode flag is being requested to fix Turbo animation log flooding. See [GitHub Issue #1188](https://github.com/midnightntwrk/compactc/issues/1188) for more details.
+   
 ### Tasks with Turbo
 Turbo manages tasks across the monorepo, defined in `turbo.json`. Key tasks:
 
 - **`compact`**:
   - Compiles `.compact` files using `compact-compile`.
-  - Run: `pnpm compact`.
+  - Run: `pnpm compact` (from within individual packages).
+  - **Note**: Running from root with `pnpm compact`, `pnpm compact:fast`, `pnpm compact:version`, or `pnpm compact:language-version` may cause output repetition issues.
 
 - **`build`**:
   - **`build:contracts`**
     - Builds contracts projects, including TypeScript compilation and artifact copying, after running `compact`.
-    - Run: `pnpm build:contracts`.
+    - Run: `pnpm build:contracts` (may cause output repetition - use individual package compilation instead).
     - Dependencies: Ensures `compact` tasks complete first.
   - **`build:apps`**
     - Builds apps projects.

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "main": "index.js",
   "scripts": {
     "prepare": "is-ci || husky",
-    "compact": "turbo run compact",
+    "compact": "for d in ./contracts/*; do if [ -d \"$d\" ]; then cd \"$d\" && pnpm compact && cd - > /dev/null; fi; done",
     "compact:fast": "turbo run compact -- --skip-zk",
     "compact:version": "turbo run compact -- --version",
     "compact:language-version": "turbo run compact -- --language-version",
-    "build:contracts": "turbo run build --filter './contracts/*'",
+    "build:contracts": "for d in ./contracts/*; do if [ -d \"$d\" ]; then cd \"$d\" && pnpm build && cd - > /dev/null; fi; done",
     "build:apps": "turbo run build --filter './apps/*'",
     "test:contracts": "turbo run test --filter './contracts/*'",
     "test:apps": "turbo run test --filter './apps/*'",

--- a/packages/compact/src/Compiler.ts
+++ b/packages/compact/src/Compiler.ts
@@ -1,10 +1,9 @@
 #!/usr/bin/env node
 
-import { exec as execCallback } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import { existsSync, readdirSync } from 'node:fs';
 import { basename, dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { promisify } from 'node:util';
 import chalk from 'chalk';
 import ora, { type Ora } from 'ora';
 
@@ -123,7 +122,6 @@ export class CompactCompiler {
     index: number,
     total: number,
   ): Promise<void> {
-    const execAsync = promisify(execCallback);
     const inputPath: string = join(SRC_DIR, file);
     const outputDir: string = join(ARTIFACTS_DIR, basename(file, '.compact'));
     const step: string = `[${index + 1}/${total}]`;
@@ -132,18 +130,43 @@ export class CompactCompiler {
     ).start();
 
     try {
-      const command: string =
-        `${COMPACTC_PATH} ${this.flags} "${inputPath}" "${outputDir}"`.trim();
-      spinner.text = chalk.blue(`[COMPILE] ${step} Running: ${command}`);
-      const { stdout, stderr }: { stdout: string; stderr: string } =
-        await execAsync(command);
-      spinner.succeed(chalk.green(`[COMPILE] ${step} Compiled ${file}`));
-      this.printOutput(stdout, chalk.cyan);
-      this.printOutput(stderr, chalk.yellow);
-    } catch (error: any) {
-      spinner.fail(chalk.red(`[COMPILE] ${step} Failed ${file}`));
-      this.printOutput(error.stdout, chalk.cyan);
-      this.printOutput(error.stderr, chalk.red);
+      const args = [...this.flags.split(' '), inputPath, outputDir].filter(
+        Boolean,
+      );
+      const command = COMPACTC_PATH;
+
+      spinner.text = chalk.blue(`[COMPILE] ${step} Compiling ${file}...`);
+
+      return new Promise((resolve, reject) => {
+        spinner.stop();
+
+        const shortCommand = basename(command);
+        console.info(chalk.blue(`  [COMPILE] ${step} ${shortCommand} ${file}`));
+
+        const process = spawn(command, args, {
+          stdio: 'inherit',
+        });
+
+        process.on('close', (code) => {
+          if (code === 0) {
+            spinner.succeed(chalk.green(`[COMPILE] ${step} ✓ ${file}`));
+            resolve();
+          } else {
+            spinner.fail(chalk.red(`[COMPILE] ${step} ✗ ${file}`));
+            reject(new Error(`Process exited with code ${code}`));
+          }
+        });
+
+        process.on('error', (err) => {
+          spinner.fail(chalk.red(`[COMPILE] ${step} ✗ ${file}`));
+          reject(err);
+        });
+      });
+    } catch (error: unknown) {
+      spinner.fail(chalk.red(`[COMPILE] ${step} ✗ ${file}`));
+      if (error instanceof Error) {
+        this.printOutput(error.message, chalk.red);
+      }
       throw error;
     }
   }


### PR DESCRIPTION
### Description

Blocked By #172 

This PR fixes the runCompiler script to show the output of the compilation results. 

After: 
```
> @midnight-dapps/math-contracts@1.0.0-alpha.1 build /home/iskander/Projects/midnight-dapps/contracts/math
> pnpm exec compact-builder && tsc

ℹ [BUILD] Compact Builder started
ℹ [COMPILE] COMPACT_HOME: /home/iskander/Downloads/compactc-linux-0.23.0
ℹ [COMPILE] COMPACTC_PATH: /home/iskander/Downloads/compactc-linux-0.23.0/compactc
ℹ [COMPILE] Found 15 .compact file(s) to compile
  [COMPILE] [1/15] compactc Index.compact
Compactc version: 0.23.0
✔ [COMPILE] [1/15] ✓ Index.compact
  [COMPILE] [2/15] compactc MathU128.compact
Compactc version: 0.23.0
✔ [COMPILE] [2/15] ✓ MathU128.compact
  [COMPILE] [3/15] compactc MathU256.compact
Compactc version: 0.23.0
✔ [COMPILE] [3/15] ✓ MathU256.compact
  [COMPILE] [4/15] compactc MathU64.compact
Compactc version: 0.23.0
✔ [COMPILE] [4/15] ✓ MathU64.compact
  [COMPILE] [5/15] compactc Max.compact
Compactc version: 0.23.0
✔ [COMPILE] [5/15] ✓ Max.compact
  [COMPILE] [6/15] compactc interfaces/IMath.compact
Compactc version: 0.23.0
✔ [COMPILE] [6/15] ✓ interfaces/IMath.compact
  [COMPILE] [7/15] compactc interfaces/IMathU128.compact
Compactc version: 0.23.0
✔ [COMPILE] [7/15] ✓ interfaces/IMathU128.compact
  [COMPILE] [8/15] compactc interfaces/IMathU256.compact
Compactc version: 0.23.0
✔ [COMPILE] [8/15] ✓ interfaces/IMathU256.compact
  [COMPILE] [9/15] compactc interfaces/IMathU64.compact
Compactc version: 0.23.0
✔ [COMPILE] [9/15] ✓ interfaces/IMathU64.compact
  [COMPILE] [10/15] compactc interfaces/IUint128.compact
Compactc version: 0.23.0
✔ [COMPILE] [10/15] ✓ interfaces/IUint128.compact
  [COMPILE] [11/15] compactc interfaces/IUint256.compact
Compactc version: 0.23.0
✔ [COMPILE] [11/15] ✓ interfaces/IUint256.compact
  [COMPILE] [12/15] compactc test/mock/MockMathU128.compact
Compactc version: 0.23.0
Compiling 15 circuits:
  circuit "add" (k=10, rows=575)  
  circuit "addU128" (k=10, rows=451)  
  circuit "div" (k=12, rows=2763)  
  circuit "divRem" (k=12, rows=2804)  
  circuit "divRemU128" (k=12, rows=2680)  
  circuit "divU128" (k=12, rows=2626)  
  circuit "isMultiple" (k=12, rows=2744)  
  circuit "isMultipleU128" (k=12, rows=2620)  
  circuit "mul" (k=11, rows=1874)  
  circuit "mulU128" (k=11, rows=1750)  
  circuit "rem" (k=12, rows=2763)  
  circuit "remU128" (k=12, rows=2626)  
  circuit "sqrt" (k=12, rows=3525)  
  circuit "sqrtU128" (k=12, rows=3453)  
  circuit "toU128" (k=10, rows=158)  
✔ [COMPILE] [12/15] ✓ test/mock/MockMathU128.compact                               
  [COMPILE] [13/15] compactc test/mock/MockMathU256.compact
Compactc version: 0.23.0
Compiling 8 circuits:
  circuit "add" (k=11, rows=1305)  
  circuit "div" (k=14, rows=10878)  
  circuit "divRem" (k=14, rows=10986)  
  circuit "isMultiple" (k=14, rows=10863)  
  circuit "mul" (k=14, rows=9249)  
  circuit "rem" (k=14, rows=10878)  
  circuit "sqrt" (k=14, rows=11693)  
  circuit "sub" (k=11, rows=1271)  
✔ [COMPILE] [13/15] ✓ test/mock/MockMathU256.compact                               
  [COMPILE] [14/15] compactc test/mock/MockMathU64.compact
Compactc version: 0.23.0
Compiling 5 circuits:
  circuit "div" (k=10, rows=240)  
  circuit "divRem" (k=10, rows=277)  
  circuit "isMultiple" (k=10, rows=243)  
  circuit "rem" (k=10, rows=240)  
  circuit "sqrt" (k=10, rows=122)  
✔ [COMPILE] [14/15] ✓ test/mock/MockMathU64.compact                                
  [COMPILE] [15/15] compactc test/mock/MockMax.compact
Compactc version: 0.23.0
✔ [COMPILE] [15/15] ✓ test/mock/MockMax.compact
✔ [BUILD] [1/3] Compiling TypeScript
✔ [BUILD] [2/3] Copying artifacts
✔ [BUILD] [3/3] Copying and cleaning .compact files
```