### PR TITLE
fix(contracts): drop GPL-licensed @subsquid transitive deps

### DIFF
--- a/contracts/package.json
+++ b/contracts/package.json
@@ -64,7 +64,6 @@
   },
   "dependencies": {
     "@midnight-ntwrk/midnight-js-network-id": "3.0.0",
-    "@midnight-ntwrk/wallet-sdk-address-format": "3.0.0",
     "@midnight-ntwrk/zswap": "4.0.0",
     "@midnight-ntwrk/compact-runtime": "0.14.0"
   }

--- a/contracts/src/shielded-token/test/ShieldedFungibleToken.test.ts
+++ b/contracts/src/shielded-token/test/ShieldedFungibleToken.test.ts
@@ -3,14 +3,9 @@ import {
   rawTokenType,
 } from '@midnight-ntwrk/compact-runtime';
 import {
-  getNetworkId,
   type NetworkId,
   setNetworkId,
 } from '@midnight-ntwrk/midnight-js-network-id';
-import {
-  MidnightBech32m,
-  ShieldedAddress,
-} from '@midnight-ntwrk/wallet-sdk-address-format';
 import type {
   ContractAddress,
   Either,
@@ -33,16 +28,35 @@ const NETWORK_ID: NetworkId = 'test';
 
 setNetworkId(NETWORK_ID);
 
-// Helper function to create Either for hex addresses
+const hexToBytes = (hex: string): Uint8Array => {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+};
+
+// Coin public keys for the static test addresses above, pre-decoded from their
+// bech32m shielded-address form. Inlined so the test does not depend on
+// @midnight-ntwrk/wallet-sdk-address-format, which pulls in GPL-licensed
+// transitive dependencies (@subsquid/*).
+const COIN_PUBLIC_KEYS: Record<string, Uint8Array> = {
+  [ADMIN]: hexToBytes(
+    '208b4cd79c3c8e75f99264a60391cc28bc3455a46760538affb2c0b6de5a7be6',
+  ),
+  [USER]: hexToBytes(
+    'd271f57c33edd9f01d9e2af6e77c3fbe7088c1e7e9b1c9b836c8848b50b64a9e',
+  ),
+};
+
+// Helper function to create Either for the static test addresses
 const createEitherFromHex = (
-  hexString: string,
+  address: string,
 ): Either<ZswapCoinPublicKey, ContractAddress> => {
-  const bech32mAddress = MidnightBech32m.parse(hexString);
-  const shieldedAddress = ShieldedAddress.codec.decode(
-    getNetworkId(),
-    bech32mAddress,
-  );
-  const coinPublicKeyBytes = shieldedAddress.coinPublicKey.data;
+  const coinPublicKeyBytes = COIN_PUBLIC_KEYS[address];
+  if (!coinPublicKeyBytes) {
+    throw new Error(`No precomputed coin public key for address ${address}`);
+  }
   return {
     is_left: true,
     left: { bytes: coinPublicKeyBytes },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,9 +258,6 @@ importers:
       '@midnight-ntwrk/midnight-js-network-id':
         specifier: 3.0.0
         version: 3.0.0
-      '@midnight-ntwrk/wallet-sdk-address-format':
-        specifier: 3.0.0
-        version: 3.0.0
       '@midnight-ntwrk/zswap':
         specifier: 4.0.0
         version: 4.0.0
@@ -842,6 +839,9 @@ packages:
   '@midnight-ntwrk/compact-runtime@0.14.0':
     resolution: {integrity: sha512-VfZmfPDedRUPAYIhKAgS5y+KtxOkSSOCS24PAsGMjhMpzJaaWVSd5SajF6HtNZsciL54sqru4EpWvmCAqsbmYQ==}
 
+  '@midnight-ntwrk/compact-runtime@0.15.0':
+    resolution: {integrity: sha512-6+odrxb83ZZwF29SqNBBgaOR3hf5ej4KZVGibDwdXta9+uiv6qYW0fMrsKP9S+c2AqvY+vEb5NEFFI54lA7G5A==}
+
   '@midnight-ntwrk/dapp-connector-api@4.0.0':
     resolution: {integrity: sha512-XiAesY32uPPDYOk6MXquO1lDsUhe7J/CMbMOIfEgjwDgXfkLvvKFMfNz672O1aSJYkqm1I65o2XjPXNnwloQtA==}
 
@@ -854,13 +854,13 @@ packages:
   '@midnight-ntwrk/onchain-runtime-v2@2.0.0':
     resolution: {integrity: sha512-9LfU3xJDI4aWcElE4ZxsGLKKAjj/7+O6nepvqMngojc+YLmlpR29ju4C+/isDbBk/4m/9m9fq89d8qIvX8Y4/Q==}
 
+  '@midnight-ntwrk/onchain-runtime-v3@3.0.0':
+    resolution: {integrity: sha512-HbFbUOsvgpEFy1OT0Ni2LMFk4jnMQS1em+H+Mof/B3DpnNKl0Lkx5QiulKOc6pyU4KPEagOqx4fYNyVXFwgZ7g==}
+
   '@midnight-ntwrk/wallet-api@5.0.0':
     resolution: {integrity: sha512-L5Z9+v+ouqTtPLoXpngtBVHZ0SmC3zLrCZbuYnd/ul6p9UbwUQ3AQeqMhclv2jhwFRNYsL0fBOqpD5dvs4SvLQ==}
     peerDependencies:
       rxjs: 7.x
-
-  '@midnight-ntwrk/wallet-sdk-address-format@3.0.0':
-    resolution: {integrity: sha512-h46Dq+vY6Ymbll58tZyHJGd0dJmNE/Ae2PJKslP3Mb8rpDG0HhiGcqYkGvRxH6Tc/MqM0yABgAcQetjcvIe8qA==}
 
   '@midnight-ntwrk/zswap@4.0.0':
     resolution: {integrity: sha512-yKfzp4M/wUkqxUJv1D2SizojYdWYnF3FDeKaxPehLPOFC4BrR9KnLZsNR2Y/occ8a4yFDtQXf7bN1QvK5k7Grw==}
@@ -1932,23 +1932,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@scure/base@1.2.6':
-    resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
-
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
-
-  '@subsquid/scale-codec@4.0.1':
-    resolution: {integrity: sha512-H3mi5GIvlrvOSJVSYQRNnaiulSDktPF4TwUvquAgN86tN4kokyX8XcEM2Htrm1sVWRtMi7SgYpyVR5Yg5iPKUQ==}
-
-  '@subsquid/util-internal-hex@1.2.2':
-    resolution: {integrity: sha512-E43HVqf23jP5hvtWF9GsiN8luANjnJ1daR2SVTwaIUAYU/uNjv1Bi6tHz2uexlflBhyxAgBDmHgunXZ45wQTIw==}
-
-  '@subsquid/util-internal-json@1.2.3':
-    resolution: {integrity: sha512-H5qW5kG20IzVMpb7GhPbVRxGuACEf1DPIXE1+LNXYxt8t/GX4zQREQWHRvCB3lck+RORLJD3WJbQUtxN5UYB3Q==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -2679,6 +2667,7 @@ packages:
   git-raw-commits@4.0.0:
     resolution: {integrity: sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==}
     engines: {node: '>=16'}
+    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
     hasBin: true
 
   glob-parent@5.1.2:
@@ -2691,6 +2680,7 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   global-directory@4.0.1:
@@ -3060,6 +3050,7 @@ packages:
   next@15.4.8:
     resolution: {integrity: sha512-jwOXTz/bo0Pvlf20FSb6VXVeWRssA2vbvq9SdrOPEg9x8E1B27C2rQtvriAn600o9hH61kjrVRexEffv3JybuA==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
+    deprecated: This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/security-update-2025-12-11 for more details.
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
@@ -3577,6 +3568,7 @@ packages:
   tar@7.4.3:
     resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   test-exclude@7.0.1:
     resolution: {integrity: sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==}
@@ -4375,6 +4367,12 @@ snapshots:
       '@types/object-inspect': 1.13.0
       object-inspect: 1.13.4
 
+  '@midnight-ntwrk/compact-runtime@0.15.0':
+    dependencies:
+      '@midnight-ntwrk/onchain-runtime-v3': 3.0.0
+      '@types/object-inspect': 1.13.0
+      object-inspect: 1.13.4
+
   '@midnight-ntwrk/dapp-connector-api@4.0.0': {}
 
   '@midnight-ntwrk/ledger-v7@7.0.0': {}
@@ -4383,16 +4381,12 @@ snapshots:
 
   '@midnight-ntwrk/onchain-runtime-v2@2.0.0': {}
 
+  '@midnight-ntwrk/onchain-runtime-v3@3.0.0': {}
+
   '@midnight-ntwrk/wallet-api@5.0.0(rxjs@7.8.2)':
     dependencies:
       '@midnight-ntwrk/zswap': 4.0.0
       rxjs: 7.8.2
-
-  '@midnight-ntwrk/wallet-sdk-address-format@3.0.0':
-    dependencies:
-      '@midnight-ntwrk/ledger-v7': 7.0.0
-      '@scure/base': 1.2.6
-      '@subsquid/scale-codec': 4.0.1
 
   '@midnight-ntwrk/zswap@4.0.0': {}
 
@@ -4442,7 +4436,8 @@ snapshots:
 
   '@openzeppelin/compact-tools-simulator@file:compact-tools/packages/simulator':
     dependencies:
-      '@midnight-ntwrk/compact-runtime': 0.14.0
+      '@midnight-ntwrk/compact-runtime': 0.15.0
+      '@midnight-ntwrk/ledger-v7': 7.0.0
 
   '@pinojs/redact@0.4.0': {}
 
@@ -5430,22 +5425,9 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.41.1':
     optional: true
 
-  '@scure/base@1.2.6': {}
-
   '@standard-schema/spec@1.0.0': {}
 
   '@standard-schema/utils@0.3.0': {}
-
-  '@subsquid/scale-codec@4.0.1':
-    dependencies:
-      '@subsquid/util-internal-hex': 1.2.2
-      '@subsquid/util-internal-json': 1.2.3
-
-  '@subsquid/util-internal-hex@1.2.2': {}
-
-  '@subsquid/util-internal-json@1.2.3':
-    dependencies:
-      '@subsquid/util-internal-hex': 1.2.2
 
   '@swc/helpers@0.5.15':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -839,9 +839,6 @@ packages:
   '@midnight-ntwrk/compact-runtime@0.14.0':
     resolution: {integrity: sha512-VfZmfPDedRUPAYIhKAgS5y+KtxOkSSOCS24PAsGMjhMpzJaaWVSd5SajF6HtNZsciL54sqru4EpWvmCAqsbmYQ==}
 
-  '@midnight-ntwrk/compact-runtime@0.15.0':
-    resolution: {integrity: sha512-6+odrxb83ZZwF29SqNBBgaOR3hf5ej4KZVGibDwdXta9+uiv6qYW0fMrsKP9S+c2AqvY+vEb5NEFFI54lA7G5A==}
-
   '@midnight-ntwrk/dapp-connector-api@4.0.0':
     resolution: {integrity: sha512-XiAesY32uPPDYOk6MXquO1lDsUhe7J/CMbMOIfEgjwDgXfkLvvKFMfNz672O1aSJYkqm1I65o2XjPXNnwloQtA==}
 
@@ -853,9 +850,6 @@ packages:
 
   '@midnight-ntwrk/onchain-runtime-v2@2.0.0':
     resolution: {integrity: sha512-9LfU3xJDI4aWcElE4ZxsGLKKAjj/7+O6nepvqMngojc+YLmlpR29ju4C+/isDbBk/4m/9m9fq89d8qIvX8Y4/Q==}
-
-  '@midnight-ntwrk/onchain-runtime-v3@3.0.0':
-    resolution: {integrity: sha512-HbFbUOsvgpEFy1OT0Ni2LMFk4jnMQS1em+H+Mof/B3DpnNKl0Lkx5QiulKOc6pyU4KPEagOqx4fYNyVXFwgZ7g==}
 
   '@midnight-ntwrk/wallet-api@5.0.0':
     resolution: {integrity: sha512-L5Z9+v+ouqTtPLoXpngtBVHZ0SmC3zLrCZbuYnd/ul6p9UbwUQ3AQeqMhclv2jhwFRNYsL0fBOqpD5dvs4SvLQ==}
@@ -4367,12 +4361,6 @@ snapshots:
       '@types/object-inspect': 1.13.0
       object-inspect: 1.13.4
 
-  '@midnight-ntwrk/compact-runtime@0.15.0':
-    dependencies:
-      '@midnight-ntwrk/onchain-runtime-v3': 3.0.0
-      '@types/object-inspect': 1.13.0
-      object-inspect: 1.13.4
-
   '@midnight-ntwrk/dapp-connector-api@4.0.0': {}
 
   '@midnight-ntwrk/ledger-v7@7.0.0': {}
@@ -4380,8 +4368,6 @@ snapshots:
   '@midnight-ntwrk/midnight-js-network-id@3.0.0': {}
 
   '@midnight-ntwrk/onchain-runtime-v2@2.0.0': {}
-
-  '@midnight-ntwrk/onchain-runtime-v3@3.0.0': {}
 
   '@midnight-ntwrk/wallet-api@5.0.0(rxjs@7.8.2)':
     dependencies:
@@ -4436,8 +4422,7 @@ snapshots:
 
   '@openzeppelin/compact-tools-simulator@file:compact-tools/packages/simulator':
     dependencies:
-      '@midnight-ntwrk/compact-runtime': 0.15.0
-      '@midnight-ntwrk/ledger-v7': 7.0.0
+      '@midnight-ntwrk/compact-runtime': 0.14.0
 
   '@pinojs/redact@0.4.0': {}
 


### PR DESCRIPTION
## Types of changes

What types of changes does your code introduce to OpenZeppelin Midnight Contracts?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

Fixes #??? <!-- No tracking issue; flagged during a license/SBOM compliance review. -->

### Reason

A license/SBOM review flagged **GPL-3.0-or-later** packages in our
dependency tree. GPL is not permitted; LGPL and Apache-2.0 are fine.

The GPL offenders are three `@subsquid/*` packages, all
`GPL-3.0-or-later`:

- `@subsquid/scale-codec`
- `@subsquid/util-internal-hex`
- `@subsquid/util-internal-json`

They entered the graph transitively through a single direct dependency
of the `contracts` package:

```
contracts → @midnight-ntwrk/wallet-sdk-address-format (Apache-2.0)
          → @subsquid/scale-codec (GPL-3.0-or-later)
          → @subsquid/util-internal-{hex,json} (GPL-3.0-or-later)
```

`wallet-sdk-address-format` is the **sole** entry point for the GPL
chain — nothing else in the workspace depends on it. It was used in
exactly **one test file** (`ShieldedFungibleToken.test.ts`), never in
production code, to decode two static bech32m shielded addresses into
coin public keys.

A simple version bump is not an option: **every** published version of
`@subsquid/scale-codec` is `GPL-3.0-or-later`, so there is no non-GPL
version to override to.

### Changes

- Remove `@midnight-ntwrk/wallet-sdk-address-format` from
  `contracts/package.json`.
- Replace the test's `createEitherFromHex` helper: the two address →
  coin-public-key mappings are now **pre-decoded and inlined** as 32-byte
  constants instead of decoded at runtime via the dropped package. The
  test is behaviour-identical (it never asserts on these bytes).
- Regenerate `pnpm-lock.yaml`, which removes the entire GPL `@subsquid/*`
  chain and `wallet-sdk-address-format`.

> Note: the `@img/sharp-*` packages in the same SBOM are `LGPL-3.0-or-later`
> and are **not** affected by this PR — LGPL is permitted.

### Verification

- `pnpm-lock.yaml` no longer references `@subsquid/*` or
  `wallet-sdk-address-format` (confirmed by grep).
- All `ShieldedFungibleToken` tests that exercise the changed helper
  (mint / burn / multi-recipient) pass locally.

## PR Checklist

- [ ] I have read the [Contributing Guide](CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added documentation of new methods and any new behavior or changes to existing behavior
- [ ] CI Workflows Are Passing

#### Further comments

Alternatives considered:

- **Override the subsquid version** — rejected: all published versions
  are GPL.
- **Keep the dependency, add a license exception** — rejected: the dep
  is only used by one test and is trivially removable, so eliminating it
  is cleaner than carrying a GPL exception.
- **Remove/skip the test** — rejected: the test is valuable; only its
  address-decoding setup needed the GPL package, and that is now inlined.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated shielded token tests to use simpler local helpers for address handling.
  * Test data now relies on precomputed public key values instead of runtime address decoding.

* **Chores**
  * Removed an unused package dependency from the contracts package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->